### PR TITLE
Fix clippy linting errors

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -15,7 +15,7 @@ pub fn write_response(mut stream: TcpStream, response: Response<String>) -> IoRe
     // writing headers
     for (key, value) in response.headers().iter() {
         if let Ok(value) = String::from_utf8(value.as_ref().to_vec()) {
-            write!(stream, "{}: {}\r\n", key.to_string(), value)?;
+            write!(stream, "{}: {}\r\n", key, value)?;
         }
     }
     // separator between header and data
@@ -24,7 +24,7 @@ pub fn write_response(mut stream: TcpStream, response: Response<String>) -> IoRe
     Ok(())
 }
 
-pub fn parse_request<'a>(mut stream: TcpStream) -> Request<String> {
+pub fn parse_request(mut stream: TcpStream) -> Request<String> {
     let mut headers = [httparse::EMPTY_HEADER; 16];
     let mut buf = [0; 200];
     if let Err(e) = stream.read(&mut buf) {
@@ -59,9 +59,7 @@ pub fn parse_request<'a>(mut stream: TcpStream) -> Request<String> {
     }
 
     // TODO: handle error if non-utf8 data received
-    let request = request_builder
+    request_builder
         .body::<String>(String::from_utf8(body).unwrap())
-        .unwrap();
-
-    request
+        .unwrap()
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -58,3 +58,9 @@ impl Router {
         defaults::err_404
     }
 }
+
+impl Default for Router {
+    fn default() -> Self {
+        Router::new()
+    }
+}


### PR DESCRIPTION
I am not sure how strict we'd like to be with clippy lints and such, but I had a few after pulling from main.

We could setup a github bot to do some checks for us.
Here's a `.github/workflows/ci.yml` file from a previous project for example:
```yaml
name: Rust

concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true

on:
  push:
    branches: [ master ]
  pull_request:
    branches: [ master ]

env:
  CARGO_TERM_COLOR: always

jobs:
  rust_checks:
    name: Rust basic checks on (${{ matrix.os }})
    runs-on: ${{ matrix.os }}
    strategy:
      matrix:
        rust: [stable]
        os: [ubuntu-latest]
        rust_target: [wasm32-unknown-unknown]
    env:
      RUST_BACKTRACE: full

    steps:
      - uses: actions/checkout@v2

      - name: Install Rust ${{ matrix.rust }}
        uses: actions-rs/toolchain@v1
        with:
          toolchain: ${{ matrix.rust }}
          profile: minimal
          override: true
          target: ${{ matrix.rust_target }}

      - uses: Swatinem/rust-cache@v1
        with:
          key: ${{ matrix.os }}

      - name: fmt
        run: cargo fmt --check

      - name: Build
        run: cargo build

      - name: install wasm-bindgen-cli
        run: cargo install wasm-bindgen-cli

      - name: Test
        run: cargo test

  trunk_checks:
    name: Build with trunk on (${{ matrix.os }})
    runs-on: ${{ matrix.os }}
    strategy:
      matrix:
        rust: [stable]
        os: [ubuntu-latest]
        rust_target: [wasm32-unknown-unknown]
    env:
      RUST_BACKTRACE: full

    steps:
      - uses: actions/checkout@v2

      - name: Install Rust ${{ matrix.rust }}
        uses: actions-rs/toolchain@v1
        with:
          toolchain: ${{ matrix.rust }}
          profile: minimal
          override: true
          target: ${{ matrix.rust_target }}

      - uses: Swatinem/rust-cache@v1
        with:
          key: ${{ matrix.os }}-trunk

      - name: Install trunk
        run: cargo install trunk --locked

      - name: Build with trunk
        run: make build
```