### PR TITLE
Add docsrs feature flag support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ submillisecond = { path = ".", features = ["json", "query"] }                   
 ron = "0.7"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [[bench]]
 harness = false
 name = "router"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 use std::{io, mem};
 
 pub use http;


### PR DESCRIPTION
Adds support for docs.rs to show which items are behind feature flags.

![Screenshot_20220728_203427](https://user-images.githubusercontent.com/16362377/181490634-1c3283d7-b4af-40c6-a502-5bd903853b77.png)

Without this PR, items behind feature flags would not be visible on docs.rs.

To test this locally, you'll need to ensure you have `rust-src` component for nightly installed.
On linux this is:
```bash
$ rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
```

You can then run rustdoc with nightly using this command:
```bash
$ cargo +nightly -Zbuild-std rustdoc -p submillisecond --target wasm32-wasi --all-features --open -- --cfg docsrs
```