### PR TITLE
Add support for custom handler types

### DIFF
--- a/examples/custom_handler.rs
+++ b/examples/custom_handler.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+use submillisecond::response::{IntoResponse, Response};
+use submillisecond::{Application, Handler, RequestContext};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct AppHandler {
+    foo: String,
+}
+
+impl Handler for AppHandler {
+    fn handle(&self, req: RequestContext) -> Response {
+        println!("New request: {}", req.uri().path());
+
+        "ok".into_response()
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    Application::new_custom(AppHandler {
+        foo: "Hey!".to_string(),
+    })
+    .serve("0.0.0.0:3000")
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,3 +1,5 @@
+use lunatic::function::FuncRef;
+
 use crate::extract::{FromOwnedRequest, FromRequest};
 use crate::response::IntoResponse;
 use crate::{RequestContext, Response};
@@ -82,6 +84,33 @@ macro_rules! impl_handler {
                         Err(err) => return err.into_response(),
                     };
                     self(e1 $(, $( [< $args:lower >] ),*)?).into_response()
+                }
+            }
+        }
+
+        #[allow(unused_parens)]
+        impl<F, $arg1, $( $( $args, )*)? R> Handler<($arg1$(, $( $args, )*)?), R> for FuncRef<F>
+        where
+            F: Fn($arg1$(, $( $args, )*)?) -> R + lunatic::function::reference::Fn<F> + Copy,
+            $arg1: FromOwnedRequest,
+            $( $( $args: FromRequest, )* )?
+            R: IntoResponse,
+        {
+
+            #[allow(unused_mut, unused_variables)]
+            fn handle(&self, mut req: RequestContext) -> Response {
+                paste::paste! {
+                    $($(
+                        let [< $args:lower >] = match <$args as FromRequest>::from_request(&mut req) {
+                            Ok(e) => e,
+                            Err(err) => return err.into_response(),
+                        };
+                    )*)?
+                    let e1 = match <$arg1 as FromOwnedRequest>::from_owned_request(req) {
+                        Ok(e) => e,
+                        Err(err) => return err.into_response(),
+                    };
+                    self.get()(e1 $(, $( [< $args:lower >] ),*)?).into_response()
                 }
             }
         }

--- a/src/request.rs
+++ b/src/request.rs
@@ -8,6 +8,7 @@ use crate::reader::UriReader;
 use crate::Response;
 
 /// Wrapper for [`http::Request`] containing params and cursor.
+#[derive(Debug)]
 pub struct RequestContext {
     /// The [`http::Request`] instance.
     pub request: http::Request<Body<'static>>,


### PR DESCRIPTION
Closes #80 

This PR lets you pass any type that implements `Handler + Serialize + DeserializeOwned + Clone` into `Application::new_custom`.

I had to separate `new_custom` instead of reuse `new` since the new function takes a function pointer directly, and wraps the handler in `FuncRef::new`.

https://github.com/lunatic-solutions/submillisecond/blob/ce0360dff7011aa450f5eea32900a60c618864a7/examples/custom_handler.rs#L5-L23

I'm not too happy with the name of `new_custom`, if anyone has a better suggestion for the name of that please let me know :)