### PR TITLE
Allow all process-safe handlers in `Application::new`

### DIFF
--- a/examples/custom_handler.rs
+++ b/examples/custom_handler.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+use submillisecond::response::IntoResponse;
+use submillisecond::{Application, Handler};
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Name(String);
+
+impl Handler for Name {
+    fn handle(&self, _req: submillisecond::RequestContext) -> submillisecond::response::Response {
+        format!("Hello {}!", self.0).into_response()
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    Application::new(Name("World".into())).serve("0.0.0.0:3000")
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,6 +1,81 @@
+use lunatic::function::reference::Fn as FnPtr;
+use lunatic::function::FuncRef;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
 use crate::extract::{FromOwnedRequest, FromRequest};
 use crate::response::IntoResponse;
 use crate::{RequestContext, Response};
+
+/// Implemented for process-safe [`Handlers`](Handler).
+///
+/// Submillisecond handles every request in a separate [lunatic
+/// process](Process), and lunatic's processes are sandboxed. This means that no
+/// memory is shared between the request handler and the rest of the app. This
+/// introduces an additional limitation on what can be a [`Handler`].
+///
+/// Two kinds of types are safe to be used as handlers:
+/// - Static functions
+/// - Serializable and clonable objects
+///
+/// ### Static functions
+///
+/// This type is obvious. Non-capturing functions are generated during compile
+/// time and are shared between all processes, so they can be easily used as
+/// handlers. In fact, the [`router!`](crate::router) macro will in the end just
+/// generate a function that will be used as a handler and invoke other handlers
+/// depending on the request values.
+///
+/// ### Serializable and clonable objects
+///
+/// Everything else needs to be passed somehow to the memory of the handler
+/// process. This means that we need to clone the value for every incoming
+/// request, serialize it and send it to the process handling the request.
+pub trait ProcessSafeHandler<Kind, Arg, Ret> {
+    /// A handler is only safe if it can be cloned and safely sent between
+    /// processes.
+    type SafeHandler: Handler<Arg, Ret> + Clone + Serialize + DeserializeOwned;
+
+    /// Turn type into a safe handler.
+    fn safe_handler(self) -> Self::SafeHandler;
+}
+
+/// Marker type for functions that satisfy [`ProcessSafeHandler`].
+pub struct Function;
+/// Marker type for objects that satisfy [`ProcessSafeHandler`].
+pub struct Object;
+
+impl<T, Arg, Ret> ProcessSafeHandler<Function, Arg, Ret> for T
+where
+    T: FnPtr<T> + Copy,
+    FuncRef<T>: Handler<Arg, Ret>,
+{
+    type SafeHandler = FuncRef<T>;
+
+    fn safe_handler(self) -> Self::SafeHandler {
+        FuncRef::new(self)
+    }
+}
+
+impl<T, Arg, Ret> ProcessSafeHandler<Object, Arg, Ret> for T
+where
+    T: Clone + Handler<Arg, Ret> + Serialize + DeserializeOwned,
+{
+    type SafeHandler = T;
+
+    fn safe_handler(self) -> Self::SafeHandler {
+        self
+    }
+}
+
+impl<T, Arg, Ret> Handler<Arg, Ret> for FuncRef<T>
+where
+    T: FnPtr<T> + Copy + Handler<Arg, Ret>,
+{
+    fn handle(&self, req: RequestContext) -> Response {
+        self.get().handle(req)
+    }
+}
 
 /// A handler is implemented for any function which takes any number of
 /// [extractors](crate::extract), and returns any type that implements

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -9,11 +9,10 @@ use crate::{RequestContext, Response};
 
 /// Implemented for process-safe [`Handlers`](Handler).
 ///
-/// Submillisecond handles every request in a separate [lunatic
-/// process](lunatic::Process), and lunatic's processes are sandboxed. This
-/// means that no memory is shared between the request handler and the rest of
-/// the app. This introduces an additional limitation on what can be a
-/// [`Handler`].
+/// Submillisecond handles every request in a separate lunatic process, and
+/// lunatic's processes are sandboxed. This means that no memory is shared
+/// between the request handler and the rest of the app. This introduces an
+/// additional limitation on what can be a [`Handler`].
 ///
 /// Two kinds of types are safe to be used as handlers:
 /// - Static functions

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -10,9 +10,10 @@ use crate::{RequestContext, Response};
 /// Implemented for process-safe [`Handlers`](Handler).
 ///
 /// Submillisecond handles every request in a separate [lunatic
-/// process](Process), and lunatic's processes are sandboxed. This means that no
-/// memory is shared between the request handler and the rest of the app. This
-/// introduces an additional limitation on what can be a [`Handler`].
+/// process](lunatic::Process), and lunatic's processes are sandboxed. This
+/// means that no memory is shared between the request handler and the rest of
+/// the app. This introduces an additional limitation on what can be a
+/// [`Handler`].
 ///
 /// Two kinds of types are safe to be used as handlers:
 /// - Static functions


### PR DESCRIPTION
Everything that is a non-capturing function or implements `Handler + Clone + Serialize + Deserialize` can now be used in `Application::new`.