### PR TITLE
Fix cookies feature when used without json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = ["submillisecond_macros"]
 
 [features]
 default = ["logging"]
-cookie = ["dep:cookie"]
+cookies = ["dep:cookie", "serde_json"]
 json = ["serde_json"]
 logging = ["ansi_term", "lunatic-log"]
 query = ["serde_urlencoded"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tungstenite = { version = "0.17", optional = true }
 base64 = "0.13.0"
 criterion = { git = "https://github.com/bheisler/criterion.rs", branch = "version-0.4", default-features = false }
 submillisecond = { path = ".", features = [
-  "cookie",
+  "cookies",
   "json",
   "logging",
   "query",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub use crate::typed_header::*;
 #[macro_use]
 pub(crate) mod macros;
 
-#[cfg(feature = "cookie")]
+#[cfg(feature = "cookies")]
 pub mod cookies;
 pub mod defaults;
 pub mod extract;
@@ -82,7 +82,7 @@ pub mod extract;
 pub mod params;
 pub mod reader;
 pub mod response;
-#[cfg(feature = "cookie")]
+#[cfg(feature = "cookies")]
 pub mod session;
 #[cfg(feature = "template")]
 pub mod template;


### PR DESCRIPTION
The `cookie` feature flag fails to compile when `json` flag is not enabled.
This PR fixes this, and also renames the `cookie` feature flag to `cookies` to match the module name.