### PR TITLE
Add captures to websocket upgrade callback

### DIFF
--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -2,7 +2,7 @@ use submillisecond::websocket::{Message, WebSocket, WebSocketUpgrade};
 use submillisecond::{router, Application};
 
 fn websocket(ws: WebSocket) -> WebSocketUpgrade {
-    ws.on_upgrade(|mut conn| {
+    ws.on_upgrade((), |mut conn, ()| {
         conn.write_message(Message::text("Hello from submillisecond!"))
             .unwrap();
     })

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -104,22 +104,33 @@ pub struct WebSocket {
 impl WebSocket {
     /// Spawns a process with the established websocket connection provided to
     /// the callback.
-    pub fn on_upgrade(self, callback: fn(WebSocketConnection)) -> WebSocketUpgrade {
-        self.on_upgrade_with_config(callback, None)
+    pub fn on_upgrade<C>(
+        self,
+        captures: C,
+        callback: fn(WebSocketConnection, C),
+    ) -> WebSocketUpgrade
+    where
+        C: Serialize + for<'de> Deserialize<'de>,
+    {
+        self.on_upgrade_with_config(captures, callback, None)
     }
 
     /// Spawns a process with the established websocket connection provided to
     /// the callback with websocket options.
-    pub fn on_upgrade_with_config(
+    pub fn on_upgrade_with_config<C>(
         self,
-        callback: fn(WebSocketConnection),
+        captures: C,
+        callback: fn(WebSocketConnection, C),
         config: Option<WebSocketConfig>,
-    ) -> WebSocketUpgrade {
+    ) -> WebSocketUpgrade
+    where
+        C: Serialize + for<'de> Deserialize<'de>,
+    {
         let stream = self.stream.clone();
         let callback = FuncRef::new(callback);
         let process = Process::spawn_link(
-            (stream, callback, config),
-            |(stream, callback, config), mailbox: Mailbox<SupervisorResponse>| {
+            (stream, callback, captures, config),
+            |(stream, callback, captures, config), mailbox: Mailbox<SupervisorResponse>| {
                 if let lunatic::MailboxResult::Message(SupervisorResponse::ResponseSent) =
                     mailbox.receive_timeout(Duration::from_secs(5))
                 {
@@ -128,7 +139,7 @@ impl WebSocket {
                         Role::Server,
                         config.map(|config| config.into()),
                     );
-                    callback(conn.into());
+                    callback(conn.into(), captures);
                 }
             },
         );

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -87,7 +87,7 @@ impl<'de> Deserialize<'de> for WebSocketConnection {
 ///
 /// ```
 /// fn websocket(ws: WebSocket) -> WebSocketUpgrade {
-///     ws.on_upgrade(|conn| {
+///     ws.on_upgrade((), |mut conn, ()| {
 ///         conn.write_message(Message::text("Hello from submillisecond!"));
 ///     })
 /// }


### PR DESCRIPTION
Adds support to share captured variables to spawned process in websocket upgrades.

https://github.com/lunatic-solutions/submillisecond/blob/632d4ebb3a0870df82bb1b6c6a1fbbdb849295be/examples/websocket.rs#L5-L8

This could be another function, such as `.on_upgrade_with_captures`, but it feels to verbose at that point.