### PR TITLE
Add `split()` to WebSocketConnection

### DIFF
--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -1,14 +1,61 @@
-use submillisecond::websocket::{Message, WebSocket, WebSocketUpgrade};
+use lunatic::{
+    abstract_process,
+    process::{ProcessRef, StartProcess},
+    Mailbox, Process,
+};
+use submillisecond::websocket::{
+    Message, SplitSink, SplitStream, WebSocket, WebSocketConnection, WebSocketUpgrade,
+};
 use submillisecond::{router, Application};
 
-fn websocket(ws: WebSocket) -> WebSocketUpgrade {
-    ws.on_upgrade(|mut conn| {
-        conn.write_message(Message::text("Hello from submillisecond!"))
-            .unwrap();
-    })
+struct WebSocketHandler {
+    writer: SplitStream,
+}
+
+#[abstract_process]
+impl WebSocketHandler {
+    #[init]
+    fn init(this: ProcessRef<Self>, (ws_conn,): (WebSocketConnection,)) -> Self {
+        let (reader, writer) = ws_conn.split();
+
+        fn read_handler(
+            (mut reader, this): (SplitSink, ProcessRef<WebSocketHandler>),
+            _: Mailbox<()>,
+        ) {
+            loop {
+                match reader.read_message() {
+                    Ok(Message::Text(msg)) => {
+                        print!("{msg}");
+                        this.send_message("Pong".to_owned());
+                    }
+                    Ok(Message::Close(_)) => break,
+                    Ok(_) => {}
+                    Err(err) => eprintln!("Read Message Error: {err:?}"),
+                }
+            }
+        }
+
+        Process::spawn_link((reader, this), read_handler);
+
+        WebSocketHandler { writer }
+    }
+
+    #[handle_message]
+    fn send_message(&mut self, message: String) {
+        self.writer
+            .write_message(Message::text(message))
+            .unwrap_or_default();
+    }
 }
 
 fn main() -> std::io::Result<()> {
+    fn websocket(ws: WebSocket) -> WebSocketUpgrade {
+        ws.on_upgrade(|conn| {
+            lunatic_log::info!("Establish WebSocket Connection...");
+            WebSocketHandler::start_link((conn,), None);
+        })
+    }
+
     Application::new(router! {
         GET "/" => websocket
     })

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -15,7 +15,7 @@ struct WebSocketHandler {
 #[abstract_process]
 impl WebSocketHandler {
     #[init]
-    fn init(this: ProcessRef<Self>, (ws_conn,): (WebSocketConnection,)) -> Self {
+    fn init(this: ProcessRef<Self>, ws_conn: WebSocketConnection) -> Self {
         let (reader, writer) = ws_conn.split();
 
         fn read_handler(
@@ -29,7 +29,7 @@ impl WebSocketHandler {
                         this.send_message("Pong".to_owned());
                     }
                     Ok(Message::Close(_)) => break,
-                    Ok(_) => {}
+                    Ok(_) => { /* Ignore other messages */ }
                     Err(err) => eprintln!("Read Message Error: {err:?}"),
                 }
             }
@@ -51,8 +51,7 @@ impl WebSocketHandler {
 fn main() -> std::io::Result<()> {
     fn websocket(ws: WebSocket) -> WebSocketUpgrade {
         ws.on_upgrade(|conn| {
-            lunatic_log::info!("Establish WebSocket Connection...");
-            WebSocketHandler::start_link((conn,), None);
+            WebSocketHandler::start_link(conn, None);
         })
     }
 

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -9,17 +9,17 @@ use submillisecond::websocket::{
 use submillisecond::{router, Application};
 
 struct WebSocketHandler {
-    writer: SplitStream,
+    writer: SplitSink,
 }
 
 #[abstract_process]
 impl WebSocketHandler {
     #[init]
     fn init(this: ProcessRef<Self>, ws_conn: WebSocketConnection) -> Self {
-        let (reader, writer) = ws_conn.split();
+        let (writer, reader) = ws_conn.split();
 
         fn read_handler(
-            (mut reader, this): (SplitSink, ProcessRef<WebSocketHandler>),
+            (mut reader, this): (SplitStream, ProcessRef<WebSocketHandler>),
             _: Mailbox<()>,
         ) {
             loop {

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -50,7 +50,7 @@ impl WebSocketHandler {
 
 fn main() -> std::io::Result<()> {
     fn websocket(ws: WebSocket) -> WebSocketUpgrade {
-        ws.on_upgrade(|conn| {
+        ws.on_upgrade((), |conn, _| {
             WebSocketHandler::start_link(conn, None);
         })
     }

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -54,7 +54,7 @@ pub struct SplitStream {
 }
 
 impl SplitStream {
-    /// Read a message from stream, if possible.
+    /// Check if it is possible to read messages.
     pub fn can_read(&self) -> bool {
         self.ws_conn.can_read()
     }

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -47,7 +47,7 @@ impl WebSocketConnection {
     }
 }
 
-/// A `Sink` part of the split pair.
+/// A `Stream` part of the split pair.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SplitStream {
     ws_conn: WebSocketConnection,
@@ -70,7 +70,7 @@ impl SplitStream {
     }
 }
 
-/// A Stream part of the split pair.
+/// A `Sink` part of the split pair.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SplitSink {
     ws_conn: WebSocketConnection,

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -33,6 +33,17 @@ impl From<tungstenite::protocol::WebSocket<TcpStream>> for WebSocketConnection {
     }
 }
 
+impl Clone for WebSocketConnection {
+    fn clone(&self) -> Self {
+        tungstenite::WebSocket::from_raw_socket(
+            self.get_ref().clone(),
+            Role::Server,
+            Some(self.get_config().clone()),
+        )
+        .into()
+    }
+}
+
 impl ops::Deref for WebSocketConnection {
     type Target = tungstenite::protocol::WebSocket<TcpStream>;
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -49,11 +49,11 @@ impl WebSocketConnection {
 
 /// A `Sink` part of the split pair.
 #[derive(Debug, Deserialize, Serialize)]
-pub struct SplitSink {
+pub struct SplitStream {
     ws_conn: WebSocketConnection,
 }
 
-impl SplitSink {
+impl SplitStream {
     /// Read a message from stream, if possible.
     pub fn can_read(&self) -> bool {
         self.ws_conn.can_read()
@@ -72,11 +72,11 @@ impl SplitSink {
 
 /// A Stream part of the split pair.
 #[derive(Debug, Deserialize, Serialize)]
-pub struct SplitStream {
+pub struct SplitSink {
     ws_conn: WebSocketConnection,
 }
 
-impl SplitStream {
+impl SplitSink {
     /// Check if it is possible to write messages.
     ///
     /// Writing gets impossible immediately after sending or receiving `Message::Close`.

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -48,6 +48,7 @@ impl WebSocketConnection {
 }
 
 /// A `Sink` part of the split pair.
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SplitSink {
     ws_conn: WebSocketConnection,
 }
@@ -70,6 +71,7 @@ impl SplitSink {
 }
 
 /// A Stream part of the split pair.
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SplitStream {
     ws_conn: WebSocketConnection,
 }


### PR DESCRIPTION
Creates a `reader: SplitStream` and `writer: SplitSink` from a `WebSocketConnection` to split ownership between processes.

See the example to evaluate the ergonomics of this addition.
