### PR TITLE
Add `State` type and extractor

### DIFF
--- a/examples/extractors.rs
+++ b/examples/extractors.rs
@@ -48,7 +48,8 @@ fn typed_header(TypedHeader(host): TypedHeader<Host>) -> String {
 
 fn params(params: Params) -> String {
     let name = params.get("name").unwrap_or("user");
-    format!("Welcome, {name}")
+    let age = params.get("age").unwrap_or("age");
+    format!("Welcome, {name}. You are {age} years old.")
 }
 
 #[derive(NamedParam)]

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+use submillisecond::state::State;
+use submillisecond::{router, Application};
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+struct Count(i32);
+
+fn index(mut count: State<Count>) -> String {
+    // Increment count
+    count.set(Count(count.0 + 1));
+
+    // Return current count
+    format!("Count is {}", count.0)
+}
+
+fn main() -> std::io::Result<()> {
+    State::init(Count(0));
+
+    Application::new(router! {
+        GET "/" => index
+    })
+    .serve("0.0.0.0:3000")
+}

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -21,6 +21,7 @@ mod query;
 mod request;
 mod route;
 mod splat;
+mod state;
 mod string;
 mod vec;
 

--- a/src/extract/rejection.rs
+++ b/src/extract/rejection.rs
@@ -201,3 +201,19 @@ impl std::error::Error for TypedHeaderRejection {
         }
     }
 }
+
+define_rejection! {
+    #[status = INTERNAL_SERVER_ERROR]
+    #[body = "State not initialized"]
+    /// Rejection type used when loading state without initializing.
+    pub struct NotInitialized(Error);
+}
+
+composite_rejection! {
+    /// Rejection used for [`State<T>`].
+    ///
+    /// Contains one variant for each way the [`State<T>`] extractor can fail.
+    pub enum StateRejection {
+        NotInitialized,
+    }
+}

--- a/src/extract/state.rs
+++ b/src/extract/state.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+use super::rejection::{NotInitialized, StateRejection};
+use super::FromRequest;
+use crate::state::State;
+use crate::{Error, RequestContext};
+
+impl<T> FromRequest for State<T>
+where
+    T: Clone + Serialize + for<'de> Deserialize<'de>,
+{
+    type Rejection = StateRejection;
+
+    fn from_request(_req: &mut RequestContext) -> Result<Self, Self::Rejection> {
+        State::<T>::load().ok_or_else(|| {
+            StateRejection::NotInitialized(NotInitialized::from_err(Error::new(format!(
+                "state should be initialized with State::<{}>::init(state)",
+                std::any::type_name::<T>()
+            ))))
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,12 +78,12 @@ pub(crate) mod macros;
 pub mod cookies;
 pub mod defaults;
 pub mod extract;
-
 pub mod params;
 pub mod reader;
 pub mod response;
 #[cfg(feature = "cookies")]
 pub mod session;
+pub mod state;
 #[cfg(feature = "template")]
 pub mod template;
 #[cfg(feature = "websocket")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,111 @@
+//! Application state stored in a long running process.
+//!
+//! # Example
+//!
+//! ```
+//! State::init(0);
+//!
+//! #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+//! struct Count(i32);
+//!
+//! fn index(mut count: State<Count>) -> String {
+//!    // Increment count
+//!    count.set(Count(count.0 + 1));
+//!
+//!    // Return current count
+//!    format!("Count is {}", count.0)
+//! }
+//! ```
+
+use std::{fmt, ops};
+
+use lunatic::abstract_process;
+use lunatic::process::{ProcessRef, StartProcess};
+use serde::{Deserialize, Serialize};
+
+/// State stored in a process.
+///
+/// State should be initialized before use with [`State::init`], and can be
+/// updated with [`State::set`].
+///
+/// State implements [`FromRequest`](crate::extract::FromRequest), allowing it
+/// to be used as an extractor in handlers. If the state is not initialized, an
+/// internal server error will be returned to the response.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct State<T> {
+    process: ProcessRef<StateProcess<T>>,
+    state: T,
+}
+
+struct StateProcess<T> {
+    value: T,
+}
+
+impl<T> State<T>
+where
+    T: Clone + Serialize + for<'de> Deserialize<'de>,
+{
+    /// Initializes state by spawning a process.
+    pub fn init(state: T) -> Self {
+        let name = format!("submillisecond-state-{}", std::any::type_name::<T>());
+        let process = StateProcess::start(state.clone(), Some(&name));
+        State { process, state }
+    }
+
+    /// Updates the value of state.
+    pub fn set(&mut self, value: T) {
+        self.state = value.clone();
+        self.process.set(value);
+    }
+
+    /// Loads the current state.
+    ///
+    /// If the state has not initialized, `None` is returned.
+    pub fn load() -> Option<Self> {
+        let name = format!("submillisecond-state-{}", std::any::type_name::<T>());
+        let process = ProcessRef::lookup(&name)?;
+        let state = process.get();
+        Some(State { process, state })
+    }
+}
+
+impl<T> ops::Deref for State<T>
+where
+    T: Clone + Serialize + for<'de> Deserialize<'de>,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl<T> fmt::Debug for State<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <T as fmt::Debug>::fmt(&self.state, f)
+    }
+}
+
+#[abstract_process]
+impl<T> StateProcess<T>
+where
+    T: Clone + Serialize + for<'de> Deserialize<'de>,
+{
+    #[init]
+    fn init(_: ProcessRef<Self>, value: T) -> Self {
+        StateProcess { value }
+    }
+
+    #[handle_request]
+    fn get(&self) -> T {
+        self.value.clone()
+    }
+
+    #[handle_message]
+    fn set(&mut self, value: T) {
+        self.value = value;
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -67,6 +67,11 @@ where
         let state = process.get();
         Some(State { process, state })
     }
+
+    /// Consumes the wrapper, returning the wrapped inner state.
+    pub fn into_inner(self) -> T {
+        self.state
+    }
 }
 
 impl<T> ops::Deref for State<T>


### PR DESCRIPTION
Adds a `State` type to store state in an abstract process.

State can be used also as an extractor in handlers, and updated with `state.set(new_val)`.

Closes #90 