### PR TITLE
Add host extractor

### DIFF
--- a/examples/extractors.rs
+++ b/examples/extractors.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
-use headers::Host;
 use http::HeaderMap;
 use serde::Deserialize;
-use submillisecond::extract::{Path, Query, Splat};
+use submillisecond::extract::{Host, Path, Query, Splat};
 use submillisecond::params::Params;
 use submillisecond::{router, Application, Json, NamedParam, TypedHeader};
 
@@ -42,7 +41,11 @@ fn header_map(headers: HeaderMap) -> String {
         .join("\n")
 }
 
-fn typed_header(TypedHeader(host): TypedHeader<Host>) -> String {
+fn host(Host(host): Host) -> String {
+    host
+}
+
+fn typed_header(TypedHeader(host): TypedHeader<headers::Host>) -> String {
     host.to_string()
 }
 
@@ -93,6 +96,7 @@ fn main() -> std::io::Result<()> {
         GET "/" => index
         GET "/queries" => query
         GET "/header_map" => header_map
+        GET "/host" => host
         GET "/typed_header" => typed_header
         GET "/params/:name/:age" => params
         GET "/named_param/:age" => named_param

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -2,6 +2,7 @@
 //!
 //! Many of the types and implementations were taken from [Axum](https://crates.io/crates/axum).
 
+pub use host::Host;
 pub use path::Path;
 #[cfg(feature = "query")]
 pub use query::Query;
@@ -12,6 +13,7 @@ pub mod rejection;
 
 mod body;
 mod header_map;
+mod host;
 #[cfg(feature = "json")]
 mod json;
 mod method;

--- a/src/extract/host.rs
+++ b/src/extract/host.rs
@@ -1,0 +1,188 @@
+use http::header::{HeaderMap, FORWARDED};
+
+use super::rejection::{FailedToResolveHost, HostRejection};
+use super::FromRequest;
+
+const X_FORWARDED_HOST_HEADER_KEY: &str = "X-Forwarded-Host";
+
+/// Extractor that resolves the hostname of the request.
+///
+/// Hostname is resolved through the following, in order:
+/// - `Forwarded` header
+/// - `X-Forwarded-Host` header
+/// - `Host` header
+/// - request target / URI
+///
+/// Note that user agents can set `X-Forwarded-Host` and `Host` headers to
+/// arbitrary values so make sure to validate them to avoid security issues.
+#[derive(Debug, Clone)]
+pub struct Host(pub String);
+
+impl FromRequest for Host {
+    type Rejection = HostRejection;
+
+    fn from_request(req: &mut crate::RequestContext) -> Result<Self, Self::Rejection> {
+        let headers = req.headers();
+
+        if let Some(host) = parse_forwarded(headers) {
+            return Ok(Host(host.to_owned()));
+        }
+
+        if let Some(host) = headers
+            .get(X_FORWARDED_HOST_HEADER_KEY)
+            .and_then(|host| host.to_str().ok())
+        {
+            return Ok(Host(host.to_owned()));
+        }
+
+        if let Some(host) = headers
+            .get(http::header::HOST)
+            .and_then(|host| host.to_str().ok())
+        {
+            return Ok(Host(host.to_owned()));
+        }
+
+        if let Some(host) = req.uri().host() {
+            return Ok(Host(host.to_owned()));
+        }
+
+        Err(HostRejection::FailedToResolveHost(FailedToResolveHost))
+    }
+}
+
+#[allow(warnings)]
+fn parse_forwarded(headers: &HeaderMap) -> Option<&str> {
+    // if there are multiple `Forwarded` `HeaderMap::get` will return the first one
+    let forwarded_values = headers.get(FORWARDED)?.to_str().ok()?;
+
+    // get the first set of values
+    let first_value = forwarded_values.split(',').nth(0)?;
+
+    // find the value of the `host` field
+    first_value.split(';').find_map(|pair| {
+        let (key, value) = pair.split_once('=')?;
+        key.trim()
+            .eq_ignore_ascii_case("host")
+            .then(|| value.trim().trim_matches('"'))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use http::header::HeaderName;
+    use lunatic::net::TcpStream;
+
+    use super::*;
+    use crate::{Body, RequestContext};
+
+    #[lunatic::test]
+    fn host_header() {
+        let original_host = "some-domain:123";
+
+        let mut req = RequestContext::new(
+            http::Request::builder()
+                .method("GET")
+                .header(http::header::HOST, original_host)
+                .body(Body::from_slice(&[]))
+                .unwrap(),
+            TcpStream::connect("127.0.0.1:22").unwrap(),
+        );
+
+        let Host(host) = Host::from_request(&mut req).unwrap();
+
+        assert_eq!(host, original_host);
+    }
+
+    #[lunatic::test]
+    fn x_forwarded_host_header() {
+        let original_host = "some-domain:456";
+
+        let mut req = RequestContext::new(
+            http::Request::builder()
+                .method("GET")
+                .header(X_FORWARDED_HOST_HEADER_KEY, original_host)
+                .body(Body::from_slice(&[]))
+                .unwrap(),
+            TcpStream::connect("127.0.0.1:22").unwrap(),
+        );
+
+        let Host(host) = Host::from_request(&mut req).unwrap();
+
+        assert_eq!(host, original_host);
+    }
+
+    #[lunatic::test]
+    fn x_forwarded_host_precedence_over_host_header() {
+        let x_forwarded_host_header = "some-domain:456";
+        let host_header = "some-domain:123";
+
+        let mut req = RequestContext::new(
+            http::Request::builder()
+                .method("GET")
+                .header(X_FORWARDED_HOST_HEADER_KEY, x_forwarded_host_header)
+                .header(http::header::HOST, host_header)
+                .body(Body::from_slice(&[]))
+                .unwrap(),
+            TcpStream::connect("127.0.0.1:22").unwrap(),
+        );
+
+        let Host(host) = Host::from_request(&mut req).unwrap();
+
+        assert_eq!(host, x_forwarded_host_header);
+    }
+
+    #[lunatic::test]
+    fn uri_host() {
+        let mut req = RequestContext::new(
+            http::Request::builder()
+                .method("GET")
+                .uri("127.0.0.1")
+                .body(Body::from_slice(&[]))
+                .unwrap(),
+            TcpStream::connect("127.0.0.1:22").unwrap(),
+        );
+
+        let Host(host) = Host::from_request(&mut req).unwrap();
+
+        assert!(host.contains("127.0.0.1"));
+    }
+
+    #[lunatic::test]
+    fn forwarded_parsing() {
+        // the basic case
+        let headers = header_map(&[(FORWARDED, "host=192.0.2.60;proto=http;by=203.0.113.43")]);
+        let value = parse_forwarded(&headers).unwrap();
+        assert_eq!(value, "192.0.2.60");
+
+        // is case insensitive
+        let headers = header_map(&[(FORWARDED, "host=192.0.2.60;proto=http;by=203.0.113.43")]);
+        let value = parse_forwarded(&headers).unwrap();
+        assert_eq!(value, "192.0.2.60");
+
+        // ipv6
+        let headers = header_map(&[(FORWARDED, "host=\"[2001:db8:cafe::17]:4711\"")]);
+        let value = parse_forwarded(&headers).unwrap();
+        assert_eq!(value, "[2001:db8:cafe::17]:4711");
+
+        // multiple values in one header
+        let headers = header_map(&[(FORWARDED, "host=192.0.2.60, host=127.0.0.1")]);
+        let value = parse_forwarded(&headers).unwrap();
+        assert_eq!(value, "192.0.2.60");
+
+        // multiple header values
+        let headers = header_map(&[
+            (FORWARDED, "host=192.0.2.60"),
+            (FORWARDED, "host=127.0.0.1"),
+        ]);
+        let value = parse_forwarded(&headers).unwrap();
+        assert_eq!(value, "192.0.2.60");
+    }
+
+    fn header_map(values: &[(HeaderName, &str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        for (key, value) in values {
+            headers.append(key, value.parse().unwrap());
+        }
+        headers
+    }
+}

--- a/src/extract/rejection.rs
+++ b/src/extract/rejection.rs
@@ -98,6 +98,24 @@ composite_rejection! {
     }
 }
 
+define_rejection! {
+    #[status = BAD_REQUEST]
+    #[body = "No host found in request"]
+    /// Rejection type used if the [`Host`](super::Host) extractor is unable to
+    /// resolve a host.
+    pub struct FailedToResolveHost;
+}
+
+composite_rejection! {
+    /// Rejection used for [`Host`](super::Host).
+    ///
+    /// Contains one variant for each way the [`Host`](super::Host) extractor
+    /// can fail.
+    pub enum HostRejection {
+        FailedToResolveHost,
+    }
+}
+
 #[cfg(feature = "json")]
 define_rejection! {
     #[status = UNPROCESSABLE_ENTITY]


### PR DESCRIPTION
Adds an extractor `Host` that that resolves the hostname of the request.

```rust
fn host(Host(host): Host) -> String {
    host
}
```