### PR TITLE
fix router not matching certain paths with / prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       # Rust builds can take some time, cache them.
       - uses: Swatinem/rust-cache@v2
       - name: "Install lunatic"
-        run: cargo install --git https://github.com/lunatic-solutions/lunatic
+        run: cargo install --git https://github.com/lunatic-solutions/lunatic lunatic-runtime
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ persistence
 
 /.vscode
 Cargo.lock
+.DS_Store

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -33,6 +33,13 @@ impl UriReader {
         self.uri.len() == self.cursor || &self.uri[self.cursor..self.cursor + 1] == "/"
     }
 
+    /// Returns a bool indicating whether the reader has reached the end,
+    /// disregarding any trailing slash.
+    pub fn is_dangling_terminal_slash(&self) -> bool {
+        self.uri.len() == self.cursor
+            || (&self.uri[self.cursor..self.cursor + 1] == "/" && self.uri.len() - self.cursor == 1)
+    }
+
     /// Move the cursor forward based on `len`.
     pub fn read(&mut self, len: usize) {
         self.cursor += len;

--- a/submillisecond_macros/src/router/router_trie.rs
+++ b/submillisecond_macros/src/router/router_trie.rs
@@ -95,14 +95,14 @@ impl<'r> RouterTrie<'r> {
 
     /// Expand subrouters.
     fn expand_subrouters(&self) -> TokenStream {
-        let mut subrouters_expanded = self.expand_nodes("", self.subrouters.children());
-        if !subrouters_expanded.is_empty() {
+        self.expand_nodes("", self.subrouters.children())
+        // if !subrouters_expanded.is_empty() {
 
-            // subrouters_expanded.append_all(hquote! {
-            //     req.reader.reset();
-            // })
-        }
-        subrouters_expanded
+        //     // subrouters_expanded.append_all(hquote! {
+        //     //     req.reader.reset();
+        //     // })
+        // }
+        // subrouters_expanded
     }
 
     /// Expand handlers for each http method as a match statement.
@@ -440,12 +440,7 @@ impl<'r> RouterTrie<'r> {
 
         match method {
             Some(method) => {
-                if wildcard {
-                    hquote! {
-                        let _ = ::submillisecond::http::Method::#method;
-                        #expanded
-                    }
-                } else if prefix == "/" || prefix == "" && !wildcard {
+                if wildcard || (prefix == "/" || prefix.is_empty()) {
                     hquote! {
                         let _ = ::submillisecond::http::Method::#method;
                         #expanded


### PR DESCRIPTION
This should fix the issue with not matching paths like `"/" => handler_fn`, but I need a bit more testing with sub-routers. So far the queue_todo example with external and internal subrouters seemed to work, but maybe more tests would be good